### PR TITLE
setup rancher and NFS GCE servers and register 3 Packet hosts

### DIFF
--- a/environment-setup/Dockerfile
+++ b/environment-setup/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:16.04
+
+RUN apt-get update && apt-get install -y python openssh-client curl python-pip
+RUN pip install --upgrade pip google-api-python-client packet-python
+
+RUN curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-119.0.0-linux-x86_64.tar.gz
+RUN tar zxvf google-cloud-sdk-119.0.0-linux-x86_64.tar.gz
+ENV CLOUDSDK_CORE_DISABLE_PROMPTS="1"
+RUN ./google-cloud-sdk/install.sh
+RUN ./google-cloud-sdk/bin/gcloud components update
+
+ADD *.py ./
+
+ENTRYPOINT ["python"]
+

--- a/environment-setup/Makefile
+++ b/environment-setup/Makefile
@@ -1,0 +1,7 @@
+target: flake8 package
+
+flake8:
+	flake8 *.py
+
+package:
+	docker build -t rancher/longhorn-env-setup .

--- a/environment-setup/README.md
+++ b/environment-setup/README.md
@@ -1,0 +1,57 @@
+Steps to run the setupRancher.py and teardownRancher.py to setup and teardown machines for longhorn tests
+
+# first create a properties file to retrieve machine build results from container
+# it will contain CATTLE_TEST_URL and LONGHORN_BACKUP_SERVER_IP
+touch $PROPERTY_FILE_NAME
+
+# call setupRancher.py using environment variables to setup longhorn test machines
+docker run --rm -v $(pwd)/$PROPERTY_FILE_NAME:/$PROPERTY_FILE_NAME \
+    -e PROPERTY_FILE_NAME="$PROPERTY_FILE_NAME" \
+    -e GCE_SERVICE_KEY_JSON="$GCE_SERVICE_KEY_JSON" \
+    -e GCE_RANCHER_PROJECT_NAME="$GCE_RANCHER_PROJECT_NAME" \
+    -e GCE_RANCHER_PROJECT_ZONE="$GCE_RANCHER_PROJECT_ZONE" \
+    -e GCE_NFS_SERVER_NAME="$GCE_NFS_SERVER_NAME" \
+    -e GCE_RANCHER_SERVER_NAME="$GCE_RANCHER_SERVER_NAME" \
+    -e PACKET_HOST_NAMES="$PACKET_HOST_NAMES" \
+    -e PACKET_RANCHER_AUTH_TOKEN="$PACKET_RANCHER_AUTH_TOKEN" \
+    -e PACKET_RANCHER_PROJECT_ID="$PACKET_RANCHER_PROJECT_ID" \
+    -e PACKET_HOST_MACHINE_TYPE="$PACKET_HOST_MACHINE_TYPE" \
+    -e PACKET_HOST_OS_IMG="$PACKET_HOST_OS_IMG" \
+    -e PACKET_HOST_CLOUD_CONFIG="$PACKET_HOST_CLOUD_CONFIG" \
+    -e GCE_RANCHER_MACHINE_TYPE="$GCE_RANCHER_MACHINE_TYPE" \
+    -e GCE_RANCHER_OS_IMG="$GCE_RANCHER_OS_IMG" \
+    -e GCE_STARTUP_SCRIPT_RANCHER="$GCE_STARTUP_SCRIPT_RANCHER" \
+    -e GCE_STARTUP_SCRIPT_NFS="$GCE_STARTUP_SCRIPT_NFS" \
+    rancher/longhorn-env-setup setupRancher.py
+
+
+# call teardownRancher.py using environment variables to destroy longhorn test machines
+docker run --rm \
+    -e GCE_SERVICE_KEY_JSON="$GCE_SERVICE_KEY_JSON" \
+    -e GCE_RANCHER_PROJECT_NAME="$GCE_RANCHER_PROJECT_NAME" \
+    -e GCE_RANCHER_PROJECT_ZONE="$GCE_RANCHER_PROJECT_ZONE" \
+    -e GCE_NFS_SERVER_NAME="$GCE_NFS_SERVER_NAME" \
+    -e GCE_RANCHER_SERVER_NAME="$GCE_RANCHER_SERVER_NAME" \
+    -e PACKET_HOST_NAMES="$PACKET_HOST_NAMES" \
+    -e PACKET_RANCHER_AUTH_TOKEN="$PACKET_RANCHER_AUTH_TOKEN" \
+    -e PACKET_RANCHER_PROJECT_ID="$PACKET_RANCHER_PROJECT_ID" \
+    rancher/longhorn-env-setup teardownRancher.py 
+
+
+where environment variables are:
+PROPERTY_FILE_NAME:         result from running setupRancher.py, contains CATTLE_TEST_URL and LONGHORN_BACKUP_SERVER_IP
+GCE_SERVICE_KEY_JSON:       a GCE service account secrete key
+GCE_RANCHER_PROJECT_NAME:   rancher project name on GCE
+GCE_RANCHER_PROJECT_ZONE:   rancher project zone on GCE
+GCE_NFS_SERVER_NAME:        NFS server name on GCE to be created
+GCE_RANCHER_SERVER_NAME:    Rancher server name on GCE to be created
+GCE_RANCHER_MACHINE_TYPE:   Rancher server machine type, such as n1-standard-4
+GCE_RANCHER_OS_IMG:         Rancher server OS image name, such as ubuntu-1604-lts
+GCE_STARTUP_SCRIPT_RANCHER: Rancher server startup script run by GCE during boot
+GCE_STARTUP_SCRIPT_NFS:     NFS server startup script run by GCE during boot
+PACKET_HOST_NAMES:          a list of hosts to be created on Packet separated by commas, such as host1,host2,host3
+PACKET_RANCHER_AUTH_TOKEN:  rancher project auth token on Packet
+PACKET_RANCHER_PROJECT_ID:  rancher project on Packet
+PACKET_HOST_MACHINE_TYPE:   host machine type on Packet, such as baremetal_1
+PACKET_HOST_OS_IMG:         host OS image on Packet, such as ubuntu_14_04
+PACKET_HOST_CLOUD_CONFIG:   host startup script run by Packet during boot

--- a/environment-setup/common.py
+++ b/environment-setup/common.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+
+import os
+import logging
+import subprocess
+import time
+from oauth2client.client import GoogleCredentials
+from googleapiclient import discovery
+
+
+logging.basicConfig(level=logging.INFO)
+log = logging.getLogger("common")
+
+packet_rancher_auth_token = os.environ["PACKET_RANCHER_AUTH_TOKEN"]
+packet_rancher_project_id = os.environ["PACKET_RANCHER_PROJECT_ID"]
+
+gce_key_file_content = os.environ["GCE_SERVICE_KEY_JSON"]
+gce_key_file = "servicekey.json"
+gce_rancher_project_name = os.environ["GCE_RANCHER_PROJECT_NAME"]
+gce_rancher_project_zone = os.environ["GCE_RANCHER_PROJECT_ZONE"]
+
+gce_nfs_server_name = os.environ["GCE_NFS_SERVER_NAME"]
+gce_rancher_server_name = os.environ["GCE_RANCHER_SERVER_NAME"]
+packet_host_names = os.environ["PACKET_HOST_NAMES"].split(",")
+
+
+def gce_wait_for_operation(compute, operation):
+    log.info('Waiting for GCE operation to finish...')
+    while True:
+        result = compute.zoneOperations().get(
+            project=gce_rancher_project_name,
+            zone=gce_rancher_project_zone,
+            operation=operation).execute()
+
+        if result['status'] == 'DONE':
+            if 'error' in result:
+                raise Exception(result['error'])
+            return result
+
+        time.sleep(10)
+
+
+def initialize_gcloud():
+    # generate a gce_key_file from environment variable text(multi-line string)
+    servicekey_file = open(
+        os.path.join(
+            os.path.dirname(__file__),
+            gce_key_file),
+        'w')
+    servicekey_file.write(gce_key_file_content)
+    servicekey_file.close()
+
+    retCode = subprocess.call(
+        "./google-cloud-sdk/bin/gcloud auth activate-service-account \
+        --key-file " + gce_key_file,
+        shell=True)
+    if retCode != 0:
+        raise Exception("failed to gcloud auth activate-service-account")
+    retCode = subprocess.call(
+        "./google-cloud-sdk/bin/gcloud config set project " +
+        gce_rancher_project_name,
+        shell=True)
+    if retCode != 0:
+        raise Exception("failed to gcloud config set project")
+
+    # before making any python client lib call, enable oauth
+    os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = gce_key_file
+    credentials = GoogleCredentials.get_application_default()
+
+    # initialize an instance of the Google Compute Engine service
+    log.info("getting gce compute service ...")
+    compute = discovery.build('compute', 'v1', credentials=credentials)
+    return compute

--- a/environment-setup/packet-cloud-config
+++ b/environment-setup/packet-cloud-config
@@ -1,0 +1,4 @@
+#cloud-config
+runcmd:
+- wget -O /tmp/cc https://raw.githubusercontent.com/rancher/os/master/scripts/hosting/packet/packet.sh
+- bash -x /tmp/cc

--- a/environment-setup/setupRancher.py
+++ b/environment-setup/setupRancher.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python
+
+import logging
+import os
+import urllib
+import urllib2
+import subprocess
+import json
+import time
+import shlex
+import errno
+import threading
+import common
+import packet
+
+log = logging.getLogger("setup-rancher")
+
+packet_host_machine_type = os.environ["PACKET_HOST_MACHINE_TYPE"]
+packet_host_os_img = os.environ["PACKET_HOST_OS_IMG"]
+packet_host_cloud_config = os.environ["PACKET_HOST_CLOUD_CONFIG"]
+
+gce_rancher_machine_type = os.environ["GCE_RANCHER_MACHINE_TYPE"]
+gce_rancher_os_img = os.environ["GCE_RANCHER_OS_IMG"]
+gce_startup_script_rancher = os.environ["GCE_STARTUP_SCRIPT_RANCHER"]
+gce_startup_script_nfs = os.environ["GCE_STARTUP_SCRIPT_NFS"]
+
+key_label = "longhorn:test"
+
+
+def silent_remove_file(filename):
+    try:
+        os.remove(filename)
+    except OSError as e:
+        if e.errno != errno.ENOENT:  # errno.ENOENT = no such file or directory
+            raise  # re-raise exception if a different error occured
+
+
+def gce_create_instance(compute, name, gce_startup_script):
+    # Get the latest Debian Jessie image.
+    image_response = compute.images().getFromFamily(
+        project="ubuntu-os-cloud", family=gce_rancher_os_img).execute()
+    source_disk_image = image_response['selfLink']
+
+    # Configure the machine
+    machine_type = "zones/%s/machineTypes/" % common.gce_rancher_project_zone \
+        + gce_rancher_machine_type
+    log.info("startup_script: %s", gce_startup_script)
+
+    config = {
+        'name': name,
+        'machineType': machine_type,
+        'tags': "alt-http-server",
+
+        # Specify the boot disk and the image to use as a source.
+        'disks': [
+            {
+                'boot': True,
+                'autoDelete': True,
+                'initializeParams': {
+                    'sourceImage': source_disk_image,
+                }
+            }
+        ],
+
+        # Specify a network interface with NAT to access the public
+        # internet.
+        'networkInterfaces': [{
+            'network': 'global/networks/default',
+            'accessConfigs': [
+                {'type': 'ONE_TO_ONE_NAT', 'name': 'External NAT'}
+            ]
+        }],
+
+        # Allow the instance to access cloud storage and logging.
+        'serviceAccounts': [{
+            'email': 'default',
+            'scopes': [
+                'https://www.googleapis.com/auth/devstorage.read_only',
+            ]
+        }],
+
+        # Metadata is readable from the instance and allows you to
+        # pass configuration from deployment scripts to instances.
+        'metadata': {
+            'items': [{
+                # Startup script is automatically executed by the
+                # instance upon startup.
+                'key': 'startup-script',
+                'value': gce_startup_script
+            }]
+        }
+    }
+
+    return compute.instances().insert(
+        project=common.gce_rancher_project_name,
+        zone=common.gce_rancher_project_zone,
+        body=config).execute()
+
+
+def gce_get_IP(compute, name):
+    request = compute.instances().get(
+        project=common.gce_rancher_project_name,
+        zone=common.gce_rancher_project_zone,
+        instance=name)
+    vm = request.execute()
+
+    # get the external IP
+    IP = vm['networkInterfaces'][0]['accessConfigs'][0]['natIP']
+    return IP
+
+
+def packet_wait_for_creation(manager, device):
+    while True:
+        device = manager.get_device(device.id)
+        if device.state == 'active':
+            log.info("packet device name: %s is active now", device.hostname)
+            return device
+
+        log.info(
+            "waiting for packet device name: %s being created",
+            device.hostname)
+        time.sleep(60)
+
+
+def cattle_get_host_registration_command(IP):
+    # formulate a request for cattle API to get the host registration cmd
+    url = "http://" + IP + ":8080/v1/projects/1a5/registrationtokens"
+    log.info("ip: %s, url: %s", IP, url)
+
+    # first do a post to create a registration resource, with empty data body
+    values = {}
+    data = urllib.urlencode(values)
+    req = urllib2.Request(url, data)
+
+    # total wait time is 5 minutes
+    retries = 10
+    retry_wait_time = 30
+    response_json = ""
+    while retries >= 0:
+        retries -= 1
+        try:
+            response_json = urllib2.urlopen(req).read()
+            log.info("got response from the cattle server at: %s", url)
+            break
+        except urllib2.URLError:
+            if retries == -1:
+                raise
+            log.info("retrying the cattle server at: %s", url)
+            time.sleep(retry_wait_time)
+
+    # response is a json dictionary, we need to check the state to be active
+    response_map = json.loads(response_json)
+    id = response_map["id"]
+    resource = {}
+    while True:
+        response_json = urllib2.urlopen(url).read()
+        response_map = json.loads(response_json)
+        resources = response_map["data"]
+
+        # data is array of existing registration resources, so find the one we
+        # just created
+        for resource in resources:
+            if resource["id"] == id:
+                break
+        if resource["state"] == "active":
+            break
+        time.sleep(5)
+
+    return resource["command"]
+
+
+def packet_register_to_cattle(device, registration_command):
+    # get its ipv4 address
+    IP = device.ip_addresses[0]['address']
+
+    # remote run cattle registration command in packet VM instance
+    log.info(
+        "register packet host name: %s to cattle, registration_command: %s",
+        device.hostname,
+        registration_command)
+    retries = 10
+    while retries >= 0:
+        retries -= 1
+        retCode = subprocess.call(
+            "ssh -i id_rsa -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+            rancher@%s '%s'" %
+            (IP, registration_command), shell=True)
+        if retCode == 0:
+            log.info(
+                "Done registering packet host name: %s to cattle",
+                device.hostname)
+            break
+        else:
+            log.warn(
+                "Error registering packet host name: %s to cattle",
+                device.hostname)
+            if retries == -1:
+                raise Exception(
+                    "Cannot register packet host name: %s to cattle" %
+                    device.hostname)
+            log.info(
+                "retrying to register packet host name: %s using \
+                registration_command: %s",
+                device.hostname,
+                registration_command)
+            time.sleep(30)
+
+
+def packet_create_register_host(name, registration_command):
+    manager = packet.Manager(auth_token=common.packet_rancher_auth_token)
+    log.info("creating packet instance name: %s", name)
+    device = manager.create_device(
+        project_id=common.packet_rancher_project_id,
+        hostname=name,
+        plan=packet_host_machine_type,
+        facility='ewr1',
+        operating_system=packet_host_os_img,
+        userdata=packet_host_cloud_config)
+
+    # wait for initializing and reboot
+    device = packet_wait_for_creation(manager, device)
+    log.info(
+        "Packet device name: %s created, registering it to cattle ...",
+        device.hostname)
+    packet_register_to_cattle(device, registration_command)
+
+    return device
+
+
+def get_local_pub_key():
+    # ensure there is no pre-existing id_rsa and id_rsa.pub keys
+    silent_remove_file("id_rsa")
+    silent_remove_file("id_rsa.pub")
+
+    args = shlex.split('ssh-keygen -t rsa -N "" -f "./id_rsa"')
+    p = subprocess.Popen(args, stdout=subprocess.PIPE)
+    p.communicate()[0]
+    if p.returncode != 0:
+        raise Exception("Errors running ssh-keygen")
+    file = open("id_rsa.pub")
+    return file.read()
+
+
+def gce_create_server(compute, name, gce_startup_script):
+    log.info("gce create instance name: %s ...", name)
+    operation = gce_create_instance(compute, name, gce_startup_script)
+    common.gce_wait_for_operation(compute, operation['name'])
+
+    return gce_get_IP(compute, name)
+
+
+def packet_upload_key(public_key):
+    log.info("uploading packet public key: %s", public_key)
+    manager = packet.Manager(auth_token=common.packet_rancher_auth_token)
+
+    # update pre-existing key with the same label
+    ssh_keys = manager.list_ssh_keys()
+    for each in ssh_keys:
+        if each.label == key_label:
+            each.key = public_key
+            each.update()
+            return
+
+    # if it doesn't exist, then create a new one
+    manager.create_ssh_key(key_label, public_key)
+
+
+def main():
+    # generate ssh key pairs and upload public key to packet project to allow
+    # ssh into the hosts
+    public_key = get_local_pub_key()
+
+    # create GCE servers: nfs and rancher
+    compute = common.initialize_gcloud()
+    nfs_IP = gce_create_server(
+        compute,
+        common.gce_nfs_server_name,
+        gce_startup_script_nfs)
+    rancher_IP = gce_create_server(
+        compute,
+        common.gce_rancher_server_name,
+        gce_startup_script_rancher)
+    registration_command = cattle_get_host_registration_command(rancher_IP)
+    log.info("got registration_command from cattle: %s", registration_command)
+
+    # create packet hosts
+    packet_upload_key(public_key)
+
+    threads = []
+    for name in common.packet_host_names:
+        t = threading.Thread(
+            target=packet_create_register_host, args=(
+                name, registration_command))
+        t.start()
+        threads.append(t)
+
+    # wait for all devices to get ready
+    for t in threads:
+        t.join()
+
+    # set test required environment variable to a property file
+    property_file_name = os.environ["PROPERTY_FILE_NAME"]
+
+    property_file = open(
+        os.path.join(
+            os.path.dirname(__file__),
+            property_file_name),
+        'w')
+    property_file.write("CATTLE_TEST_URL=http://" + rancher_IP + ":8080\n")
+    property_file.write("LONGHORN_BACKUP_SERVER_IP=" + nfs_IP + "\n")
+    property_file.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/environment-setup/startup-nfs-script.sh
+++ b/environment-setup/startup-nfs-script.sh
@@ -1,0 +1,13 @@
+touch /startup.log
+
+apt-get update
+apt-get install nfs-kernel-server -y >> /startup.log 2>&1
+mkdir /var/nfs
+chown nobody:nogroup /var/nfs/
+echo "/var/nfs *(rw,sync,no_subtree_check)" >> /etc/exports
+echo "exporting nfs dirs ..." >> /startup.log 2>&1
+exportfs -a >> /startup.log 2>&1
+echo "starting nfs ..." >> /startup.log 2>&1
+service nfs-kernel-server start >> /startup.log 2>&1
+service nfs-kernel-server status >> /startup.log 2>&1
+showmount -e >> /startup.log 2>&1

--- a/environment-setup/startup-script.sh
+++ b/environment-setup/startup-script.sh
@@ -1,0 +1,13 @@
+touch /startup.log
+
+curl -sSL --retry 10 --retry-delay 10 https://releases.rancher.com/install-docker/1.10.3.sh| sh >> /startup.log 2>&1
+
+if command -v systemctl > /dev/null; then
+    echo "Starting docker..."  >> /startup.log 2>&1
+    systemctl stop docker >> /startup.log 2>&1
+    sleep 10
+    systemctl start docker >> /startup.log 2>&1
+fi
+
+sleep 5
+docker run -d -p 8080:8080  --privileged rancher/server:v1.1.1 >> /startup.log 2>&1

--- a/environment-setup/teardownRancher.py
+++ b/environment-setup/teardownRancher.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+
+import time
+import logging
+import common
+import packet
+
+
+log = logging.getLogger("teardown-rancher")
+
+
+def gce_delete_servers(compute, servers):
+    # get all instance names from GCE
+    result = compute.instances().list(
+        project=common.gce_rancher_project_name,
+        zone=common.gce_rancher_project_zone).execute()
+    for instance in result['items']:
+        if instance['name'] not in servers:
+            continue
+        retries = 5
+        while retries >= 0:
+            retries -= 1
+            try:
+                operation = gce_delete_instance(compute, instance['name'])
+                common.gce_wait_for_operation(compute, operation['name'])
+                break
+            except:
+                time.sleep(30)
+                continue
+
+
+def gce_delete_instance(compute, name):
+    return compute.instances().delete(
+        project=common.gce_rancher_project_name,
+        zone=common.gce_rancher_project_zone,
+        instance=name).execute()
+
+
+def packet_remove_devices(device_names):
+    manager = packet.Manager(auth_token=common.packet_rancher_auth_token)
+    devices = manager.list_devices(project_id=common.packet_rancher_project_id)
+    for each in devices:
+        if each.hostname not in device_names:
+            continue
+        retries = 5
+        while retries >= 0:
+            retries -= 1
+            try:
+                each.delete()
+                break
+            except:
+                time.sleep(30)
+                continue
+
+
+def main():
+    compute = common.initialize_gcloud()
+
+    # destroy machines
+    packet_remove_devices(common.packet_host_names)
+    gce_delete_servers(compute,
+                       [common.gce_rancher_server_name,
+                        common.gce_nfs_server_name])
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
@yasker @sangeethah

python scripts for setting up GCE VMs and Packet hosts: setupRancher.py and teardownRancher.py running in a container from docker image jimeng/longhorn-test:01

Jenkins jobs using the scripts: http://jenkins-poc.rancher.io:8080/job/test_longhorn_driver/
and also a quick cleanup job: http://jenkins-poc.rancher.io:8080/view/storage/job/test_longhorn_teardown/

