### PR TITLE
manager: Add offline engine upgrade test

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -95,6 +95,16 @@ def wait_for_volume_delete(client, name):
     assert not found
 
 
+def wait_for_volume_engine_image(client, name, image):
+    for i in range(RETRY_COUNTS):
+        volume = client.by_id_volume(name)
+        if volume["engineImage"] == image:
+            break
+        time.sleep(RETRY_ITERVAL)
+    assert volume["engineImage"] == image
+    return volume
+
+
 def wait_for_snapshot_purge(volume, *snaps):
     for i in range(RETRY_COUNTS):
         snapshots = volume.snapshotList(volume=volume["name"])

--- a/manager/integration/tests/conftest.py
+++ b/manager/integration/tests/conftest.py
@@ -1,0 +1,26 @@
+import pytest
+
+
+ENGINE_UPGRADE_IMAGE_OPT = "--engine-upgrade-image"
+
+
+def pytest_addoption(parser):
+    parser.addoption(ENGINE_UPGRADE_IMAGE_OPT, action="store", default="",
+                     help="specify the image of engine upgrade test")
+
+
+@pytest.fixture
+def engine_upgrade_image(request):
+    return request.config.getoption(ENGINE_UPGRADE_IMAGE_OPT)
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption(ENGINE_UPGRADE_IMAGE_OPT):
+        # --upgrade-image was specified, don't skip
+        return
+    skip_upgrade = pytest.mark.skip(reason="need " +
+                                    ENGINE_UPGRADE_IMAGE_OPT +
+                                    " option to run")
+    for item in items:
+        if "engine_upgrade" in item.keywords:
+            item.add_marker(skip_upgrade)

--- a/manager/integration/tests/test_engine_upgrade.py
+++ b/manager/integration/tests/test_engine_upgrade.py
@@ -1,0 +1,56 @@
+import pytest
+
+from common import clients, volume_name  # NOQA
+from common import SIZE
+from common import wait_for_volume_state, wait_for_volume_delete
+from common import wait_for_volume_engine_image
+
+from conftest import engine_upgrade_image  # NOQA
+
+@pytest.mark.engine_upgrade  # NOQA
+def test_engine_upgrade_offline(clients, volume_name,   # NOQA
+                                engine_upgrade_image):  # NOQA
+    assert engine_upgrade_image != ""
+
+    # get a random client
+    for host_id, client in clients.iteritems():
+        break
+
+    volume = client.create_volume(name=volume_name, size=SIZE,
+                                  numberOfReplicas=2)
+    volume = wait_for_volume_state(client, volume_name, "detached")
+
+    assert volume["name"] == volume_name
+
+    original_engine_image = volume["engineImage"]
+    assert original_engine_image != engine_upgrade_image
+
+    volume.engineUpgrade(image=engine_upgrade_image)
+    volume = wait_for_volume_engine_image(client, volume_name,
+                                          engine_upgrade_image)
+
+    volume = volume.attach(hostId=host_id)
+    volume = wait_for_volume_state(client, volume_name, "healthy")
+
+    assert volume["controller"]["engineImage"] == engine_upgrade_image
+    for replica in volume["replicas"]:
+        assert replica["engineImage"] == engine_upgrade_image
+
+    volume = volume.detach()
+    volume = wait_for_volume_state(client, volume_name, "detached")
+
+    volume.engineUpgrade(image=original_engine_image)
+    volume = wait_for_volume_engine_image(client, volume_name,
+                                          original_engine_image)
+
+    assert volume["engineImage"] == original_engine_image
+
+    volume = volume.attach(hostId=host_id)
+    volume = wait_for_volume_state(client, volume_name, "healthy")
+
+    assert volume["controller"]["engineImage"] == original_engine_image
+    for replica in volume["replicas"]:
+        assert replica["engineImage"] == original_engine_image
+
+    client.delete(volume)
+    wait_for_volume_delete(client, volume_name)


### PR DESCRIPTION
Use `--engine-upgrade-image` option to enable the test. Must prepare one
additional image beforehand.