### PR TITLE
manager: Add back recurring job test

### DIFF
--- a/manager/integration/tests/conftest.py
+++ b/manager/integration/tests/conftest.py
@@ -2,11 +2,15 @@ import pytest
 
 
 ENGINE_UPGRADE_IMAGE_OPT = "--engine-upgrade-image"
+ENABLE_RECURRING_JOB_OPT = "--enable-recurring-job-test"
 
 
 def pytest_addoption(parser):
     parser.addoption(ENGINE_UPGRADE_IMAGE_OPT, action="store", default="",
                      help="specify the image of engine upgrade test")
+    parser.addoption(ENABLE_RECURRING_JOB_OPT, action="store_true",
+                     default="False",
+                     help="enable recurring job test or not")
 
 
 @pytest.fixture
@@ -15,12 +19,18 @@ def engine_upgrade_image(request):
 
 
 def pytest_collection_modifyitems(config, items):
-    if config.getoption(ENGINE_UPGRADE_IMAGE_OPT):
-        # --upgrade-image was specified, don't skip
-        return
-    skip_upgrade = pytest.mark.skip(reason="need " +
-                                    ENGINE_UPGRADE_IMAGE_OPT +
-                                    " option to run")
-    for item in items:
-        if "engine_upgrade" in item.keywords:
-            item.add_marker(skip_upgrade)
+    if not config.getoption(ENGINE_UPGRADE_IMAGE_OPT):
+        skip_upgrade = pytest.mark.skip(reason="need " +
+                                        ENGINE_UPGRADE_IMAGE_OPT +
+                                        " option to run")
+        for item in items:
+            if "engine_upgrade" in item.keywords:
+                item.add_marker(skip_upgrade)
+
+    if not config.getoption(ENABLE_RECURRING_JOB_OPT):
+        skip_upgrade = pytest.mark.skip(reason="need " +
+                                        ENABLE_RECURRING_JOB_OPT +
+                                        " option to run")
+        for item in items:
+            if "recurring_job" in item.keywords:
+                item.add_marker(skip_upgrade)

--- a/manager/integration/tests/test_basic.py
+++ b/manager/integration/tests/test_basic.py
@@ -133,59 +133,6 @@ def test_volume_basic(clients, volume_name):  # NOQA
     assert len(volumes) == 0
 
 
-@pytest.mark.skip(reason="will rewrite later")  # NOQA
-def test_recurring_snapshot(clients, volume_name):  # NOQA
-    for host_id, client in clients.iteritems():
-        break
-
-    volume = client.create_volume(name=volume_name, size=SIZE,
-                                  numberOfReplicas=2)
-    volume = wait_for_volume_state(client, volume_name, "detached")
-
-    snap2s = {"name": "snap2s", "cron": "@every 2s",
-              "task": "snapshot", "retain": 3}
-    snap3s = {"name": "snap3s", "cron": "@every 3s",
-              "task": "snapshot", "retain": 2}
-    volume.recurringUpdate(jobs=[snap2s, snap3s])
-
-    time.sleep(0.1)
-    volume = volume.attach(hostId=host_id)
-    volume = wait_for_volume_state(client, volume_name, "healthy")
-
-    time.sleep(10)
-
-    snapshots = volume.snapshotList()
-    count = 0
-    for snapshot in snapshots:
-        if snapshot["removed"] is False:
-            count += 1
-    assert count == 5
-
-    snap4s = {"name": "snap4s", "cron": "@every 4s",
-              "task": "snapshot", "retain": 2}
-    volume.recurringUpdate(jobs=[snap2s, snap4s])
-
-    time.sleep(10)
-
-    snapshots = volume.snapshotList()
-    count = 0
-    for snapshot in snapshots:
-        if snapshot["removed"] is False:
-            count += 1
-    assert count == 7
-
-    volume = volume.detach()
-
-    wait_for_volume_state(client, volume_name, "detached")
-
-    client.delete(volume)
-
-    wait_for_volume_delete(client, volume_name)
-
-    volumes = client.list_volume()
-    assert len(volumes) == 0
-
-
 def test_snapshot(clients, volume_name):  # NOQA
     for host_id, client in clients.iteritems():
         break

--- a/manager/integration/tests/test_recurring_job.py
+++ b/manager/integration/tests/test_recurring_job.py
@@ -1,0 +1,63 @@
+import pytest
+import time
+
+from common import clients, volume_name  # NOQA
+from common import wait_for_volume_state, wait_for_volume_delete
+from common import SIZE
+
+@pytest.mark.recurring_job  # NOQA
+def test_recurring_job(clients, volume_name):  # NOQA
+    for host_id, client in clients.iteritems():
+        break
+
+    volume = client.create_volume(name=volume_name, size=SIZE,
+                                  numberOfReplicas=2)
+    volume = wait_for_volume_state(client, volume_name, "detached")
+
+    # snapshot every one minute
+    job_snap = {"name": "snap", "cron": "* * * * *",
+                "task": "snapshot", "retain": 2}
+    # backup every two minutes
+    job_backup = {"name": "backup", "cron": "*/2 * * * *",
+                  "task": "backup", "retain": 1}
+    volume.recurringUpdate(jobs=[job_snap, job_backup])
+
+    volume = volume.attach(hostId=host_id)
+    volume = wait_for_volume_state(client, volume_name, "healthy")
+
+    # 5 minutes
+    time.sleep(300)
+
+    snapshots = volume.snapshotList()
+    count = 0
+    for snapshot in snapshots:
+        if snapshot["removed"] is False:
+            count += 1
+    # 2 snapshots, 1 backup
+    assert count == 3
+
+    job_backup2 = {"name": "backup2", "cron": "* * * * *",
+                   "task": "backup", "retain": 2}
+    volume.recurringUpdate(jobs=[job_snap, job_backup2])
+
+    # 5 minutes
+    time.sleep(300)
+
+    snapshots = volume.snapshotList()
+    count = 0
+    for snapshot in snapshots:
+        if snapshot["removed"] is False:
+            count += 1
+    # 2 from job_snap, 1 from job_backup, 2 from job_backup2
+    assert count == 5
+
+    volume = volume.detach()
+
+    wait_for_volume_state(client, volume_name, "detached")
+
+    client.delete(volume)
+
+    wait_for_volume_delete(client, volume_name)
+
+    volumes = client.list_volume()
+    assert len(volumes) == 0


### PR DESCRIPTION
Use `--enable-recurring-job-test` to enable the test.

It will take more than 10 minutes, so it's disabled by default.