### PR TITLE
manager: Fix test cleanup engine image and volume

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -40,11 +40,19 @@ def cleanup_clients(clis):
     client = clis.itervalues().next()
     volumes = client.list_volume()
     for v in volumes:
-        client.delete(v)
+        # ignore the error when clean up
+        try:
+            client.delete(v)
+        except Exception:
+            pass
     images = client.list_engine_image()
     for img in images:
         if not img["default"]:
-            client.delete(img)
+            # ignore the error when clean up
+            try:
+                client.delete(img)
+            except Exception:
+                pass
 
 
 def get_client(address):

--- a/manager/integration/tests/test_engine_upgrade.py
+++ b/manager/integration/tests/test_engine_upgrade.py
@@ -15,6 +15,11 @@ def test_engine_image(clients, volume_name):  # NOQA
     for host_id, client in clients.iteritems():
         break
 
+    # can be leftover
+    default_img = common.get_default_engine_image(client)
+    default_img_name = default_img["name"]
+    default_img = wait_for_engine_image_ref_count(client, default_img_name, 0)
+
     images = client.list_engine_image()
     assert len(images) == 1
     assert images[0]["default"]


### PR DESCRIPTION
If volume/engine image already gone, don't error out.