### PR TITLE
manager: Pump in data for the integration test

### DIFF
--- a/manager/integration/deploy/test.yaml
+++ b/manager/integration/deploy/test.yaml
@@ -43,8 +43,26 @@ spec:
 #           "--enable-recurring-job-test",
 #           ]
     imagePullPolicy: Always
+    securityContext:
+      privileged: true
     env:
     - name: LONGHORN_BACKUPSTORES
       value: "s3://backupbucket@us-east-1/backupstore$minio-secret, nfs://longhorn-test-nfs-svc.default:/opt/backupstore"
+    - name: NODE_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+    volumeMounts:
+    - name: dev
+      mountPath: /dev
+    - name: proc
+      mountPath: /host/proc
+  volumes:
+  - name: dev
+    hostPath:
+      path: /dev/
+  - name: proc
+    hostPath:
+      path: /proc/
   restartPolicy: Never
   serviceAccountName: longhorn-test-service-account


### PR DESCRIPTION
Issue: https://github.com/rancher/longhorn-tests/issues/21

Positive case :

```
ubuntu@ip-172-31-7-79:~/langs/golang/src/github.com/rancher/longhorn-tests/manager/integration$ kubectl logs -f longhorn-test
+ flake8 .
+ py.test -v -s -k test_basic .
============================= test session starts ==============================
platform linux2 -- Python 2.7.14, pytest-2.9.2, py-1.5.3, pluggy-0.3.1 -- /usr/local/bin/python
cachedir: .cache
rootdir: /integration/tests, inifile:
collecting ... collected 17 items

test_basic.py::test_hosts_and_settings PASSED
test_basic.py::test_volume_basic PASSED
test_basic.py::test_volume_iscsi_basic PASSED
test_basic.py::test_snapshot PASSED
test_basic.py::test_backup PASSED
test_basic.py::test_volume_multinode PASSED

==================== 11 tests deselected by '-ktest_basic' =====================
================== 6 passed, 11 deselected in 382.41 seconds ===================
```

Negative case:

```
ubuntu@ip-172-31-7-79:~/langs/golang/src/github.com/rancher/longhorn-tests/manager/integration$ kubectl logs -f longhorn-test
+ flake8 .
+ py.test -v -s -k test_basic .
============================= test session starts ==============================
platform linux2 -- Python 2.7.14, pytest-2.9.2, py-1.5.3, pluggy-0.3.1 -- /usr/local/bin/python
cachedir: .cache
rootdir: /integration/tests, inifile:
collecting ... collected 17 items

test_basic.py::test_hosts_and_settings PASSED
test_basic.py::test_volume_basic FAILED
test_basic.py::test_volume_iscsi_basic PASSED
test_basic.py::test_snapshot PASSED
test_basic.py::test_backup PASSED
test_basic.py::test_volume_multinode PASSED

=================================== FAILURES ===================================
______________________________ test_volume_basic _______________________________

clients = {'gke-bob-cluster-2-default-pool-bfd8924a-5480': <cattle.Client object at 0x7fef05f92a50>, 'gke-bob-cluster-2-default-...nt object at 0x7fef0b6da390>, 'gke-bob-cluster-2-default-pool-bfd8924a-vvph': <cattle.Client object at 0x7fef062bce90>}
volume_name = 'longhorn-testvol-pbqrqb'

    def test_volume_basic(clients, volume_name):  # NOQA
        # get a random client
        for host_id, client in clients.iteritems():
            break

        with pytest.raises(Exception):
            volume = client.create_volume(name="wrong_volume-name-1.0", size=SIZE,
                                          numberOfReplicas=2)
            volume = client.create_volume(name="wrong_volume-name", size=SIZE,
                                          numberOfReplicas=2)
            volume = client.create_volume(name="wrong_volume-name", size=SIZE,
                                          numberOfReplicas=2,
                                          frontend="invalid_frontend")

        volume = client.create_volume(name=volume_name, size=SIZE,
                                      numberOfReplicas=3)
        assert volume["name"] == volume_name
        assert volume["size"] == SIZE
        assert volume["numberOfReplicas"] == 3
        assert volume["frontend"] == "blockdev"

        volume = wait_for_volume_state(client, volume_name, "detached")
        assert len(volume["replicas"]) == 3

        assert volume["state"] == "detached"
        assert volume["created"] != ""

        volumes = client.list_volume()
        assert len(volumes) == 1
        assert volumes[0]["name"] == volume["name"]
        assert volumes[0]["size"] == volume["size"]
        assert volumes[0]["numberOfReplicas"] == volume["numberOfReplicas"]
        assert volumes[0]["state"] == volume["state"]
        assert volumes[0]["created"] == volume["created"]

        volumeByName = client.by_id_volume(volume_name)
        assert volumeByName["name"] == volume["name"]
        assert volumeByName["size"] == volume["size"]
        assert volumeByName["numberOfReplicas"] == volume["numberOfReplicas"]
        assert volumeByName["state"] == volume["state"]
        assert volumeByName["created"] == volume["created"]

        lht_hostId = get_self_host_id()
        volume.attach(hostId=lht_hostId)
        volume = wait_for_volume_state(client, volume_name, "healthy")

        # soft anti-affinity should work, assume we have 3 nodes or more
        hosts = {}
        for replica in volume["replicas"]:
            id = replica["hostId"]
            assert id != ""
            assert id not in hosts
            hosts[id] = True
        assert len(hosts) == 3

        volumes = client.list_volume()
        assert len(volumes) == 1
        assert volumes[0]["name"] == volume["name"]
        assert volumes[0]["size"] == volume["size"]
        assert volumes[0]["numberOfReplicas"] == volume["numberOfReplicas"]
        assert volumes[0]["state"] == volume["state"]
        assert volumes[0]["created"] == volume["created"]
        assert volumes[0]["endpoint"] == DEV_PATH + volume_name

        volume = client.by_id_volume(volume_name)
        assert volume["endpoint"] == DEV_PATH + volume_name

        # RW test
>       assert volume_valid(volume["endpoint"])

test_basic.py:148:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

dev = '/dev/longhorn/longhorn-testvol-pbqrqb'

    def volume_valid(dev):
>       return stat.S_ISBLK(os.stat(dev).st_mode)
E       OSError: [Errno 2] No such file or directory: '/dev/longhorn/longhorn-testvol-pbqrqb'

common.py:232: OSError
==================== 11 tests deselected by '-ktest_basic' =====================
============= 1 failed, 5 passed, 11 deselected in 374.53 seconds ==============
```