### PR TITLE
manager: update image to rancher/longhorn-manager-test:1d5584f

### DIFF
--- a/manager/integration/deploy/test.yaml
+++ b/manager/integration/deploy/test.yaml
@@ -37,7 +37,7 @@ metadata:
 spec:
   containers:
   - name: longhorn-test-pod
-    image: rancher/longhorn-manager-test:c0a71ec
+    image: rancher/longhorn-manager-test:1d5584f
 #    args: ["-x", "-s",
 #           "-k", "test_recurring_job",
 #           "--enable-recurring-job-test",


### PR DESCRIPTION
Match longhorn-manager 885b53acb7518935546587bfcf3fc7a077fde415

Notice that the deployment method changed. See README.md for details.