### PR TITLE
manager: Update image to rancher/longhorn-manager-test:3810afb

### DIFF
--- a/manager/integration/deploy/test.yaml
+++ b/manager/integration/deploy/test.yaml
@@ -37,7 +37,7 @@ metadata:
 spec:
   containers:
   - name: longhorn-test-pod
-    image: rancher/longhorn-manager-test:a96f5e9
+    image: rancher/longhorn-manager-test:3810afb
 #    args: ["-x", "-s",
 #           "-k", "test_recurring_job",
 #           "--enable-recurring-job-test",


### PR DESCRIPTION
Matching longhorn-manager: rancher/longhorn-manager:d5227ec

From:

commit 98dd3f8fb20ad86e95fbd0429932f015c8c0b7c6
Author: Sheng Yang <sheng@yasker.org>
Date:   Fri Jul 6 19:27:42 2018 -0700

    Update images

    Manager: rancher/longhorn-manager:d5227ec
    UI: rancher/longhorn-ui:436d961

    Flexvolume driver has been updated. Need to redeploy for the testing.