### PR TITLE
manager: Disable flexvolume test temporaily

### DIFF
--- a/manager/integration/tests/conftest.py
+++ b/manager/integration/tests/conftest.py
@@ -2,7 +2,7 @@ import pytest
 
 
 ENABLE_RECURRING_JOB_OPT = "--enable-recurring-job-test"
-ENABLE_CSI_OPT = "--enable-csi-test"
+ENABLE_FLEXVOLUME_OPT = "--enable-flexvolume-test"
 
 
 def pytest_addoption(parser):
@@ -23,10 +23,10 @@ def pytest_collection_modifyitems(config, items):
             if "recurring_job" in item.keywords:
                 item.add_marker(skip_upgrade)
 
-    if not config.getoption(ENABLE_CSI_OPT):
+    if not config.getoption(ENABLE_FLEXVOLUME_OPT):
         skip_upgrade = pytest.mark.skip(reason="need " +
-                                        ENABLE_CSI_OPT +
+                                        ENABLE_FLEXVOLUME_OPT +
                                         " option to run")
         for item in items:
-            if "csi" in item.keywords:
+            if "flexvolume" in item.keywords:
                 item.add_marker(skip_upgrade)

--- a/manager/integration/tests/test_flexvolume.py
+++ b/manager/integration/tests/test_flexvolume.py
@@ -257,6 +257,7 @@ def write_volume_data(api, pod_name, test_data):
         tty=False)
 
 
+@pytest.mark.flexvolume  # NOQA
 def test_dynamic_volume_mount(clients, core_api, pvc_name):  # NOQA
     """
     Test that a StorageClass provisioned volume can be created, mounted,
@@ -291,6 +292,7 @@ def test_dynamic_volume_mount(clients, core_api, pvc_name):  # NOQA
     delete_and_wait_storage(client, pvc, pvc_volume_name)
 
 
+@pytest.mark.flexvolume  # NOQA
 def test_dynamic_volume_params(clients, core_api, pvc_name):  # NOQA
     """
     Test that substituting different StorageClass parameters is reflected in
@@ -329,6 +331,7 @@ def test_dynamic_volume_params(clients, core_api, pvc_name):  # NOQA
     delete_and_wait_storage(client, pvc, pvc_volume_name)
 
 
+@pytest.mark.flexvolume  # NOQA
 def test_dynamic_volume_io(clients, core_api, pvc_name):  # NOQA
     """
     Test that input and output on a StorageClass provisioned
@@ -364,6 +367,7 @@ def test_dynamic_volume_io(clients, core_api, pvc_name):  # NOQA
     delete_and_wait_storage(client, pvc, pvc_volume_name)
 
 
+@pytest.mark.flexvolume  # NOQA
 def test_static_volume_mount(clients, core_api, volume_name): # NOQA
     """
     Test that a statically defined volume can be created, mounted, unmounted,
@@ -396,6 +400,7 @@ def test_static_volume_mount(clients, core_api, volume_name): # NOQA
     wait_for_volume_delete(client, volume["name"])
 
 
+@pytest.mark.flexvolume  # NOQA
 def test_static_volume_io(clients, core_api, volume_name):  # NOQA
     """
     Test that input and output on a statically defined volume works as


### PR DESCRIPTION
Wait for https://github.com/rancher/longhorn-tests/issues/61 to be resolved.

For now we can only run test on Kubernetes v1.10