### PR TITLE
manager: Update delete_pod to delete_and_wait_pod()

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -117,7 +117,7 @@ def create_pvc_spec(name):
     }
 
 
-def delete_pod(api, pod_name):
+def delete_and_wait_pod(api, pod_name):
     """
     Delete a specified Pod from the "default" namespace.
 
@@ -132,6 +132,17 @@ def delete_pod(api, pod_name):
         name=pod_name,
         namespace='default',
         body=k8sclient.V1DeleteOptions())
+    for i in range(DEFAULT_POD_TIMEOUT):
+        ret = api.list_namespaced_pod(namespace='default')
+        found = False
+        for item in ret.items:
+            if item.metadata.name == pod_name:
+                found = True
+            break
+        if not found:
+            break
+        time.sleep(DEFAULT_POD_INTERVAL)
+    assert not found
 
 
 def delete_and_wait_longhorn(client, name):

--- a/manager/integration/tests/test_csi.py
+++ b/manager/integration/tests/test_csi.py
@@ -6,7 +6,7 @@ from common import clients, core_api, volume_name  # NOQA
 from common import DEFAULT_LONGHORN_PARAMS, DEFAULT_VOLUME_SIZE, Gi
 from common import VOLUME_RWTEST_SIZE
 from common import create_and_wait_pod, create_pvc_spec
-from common import delete_and_wait_longhorn, delete_pod
+from common import delete_and_wait_longhorn, delete_and_wait_pod
 from common import generate_random_data, read_volume_data, size_to_string
 from common import write_volume_data
 
@@ -107,7 +107,7 @@ def test_csi_mount(clients, core_api, volume_name): # NOQA
         int(DEFAULT_LONGHORN_PARAMS["numberOfReplicas"])
     assert volumes[0]["state"] == "attached"
 
-    delete_pod(core_api, pod_name)
+    delete_and_wait_pod(core_api, pod_name)
     delete_and_wait_pv(core_api, client, pvc)
 
 
@@ -132,7 +132,7 @@ def test_csi_io(clients, core_api, volume_name):  # NOQA
 
     test_data = generate_random_data(VOLUME_RWTEST_SIZE)
     write_volume_data(core_api, pod_name, test_data)
-    delete_pod(core_api, pod_name)
+    delete_and_wait_pod(core_api, pod_name)
     common.wait_for_volume_detached(client, volume_name)
 
     pod_name = 'csi-io-test-2'
@@ -142,5 +142,5 @@ def test_csi_io(clients, core_api, volume_name):  # NOQA
 
     assert resp == test_data
 
-    delete_pod(core_api, pod_name)
+    delete_and_wait_pod(core_api, pod_name)
     delete_and_wait_pv(core_api, client, pvc)

--- a/manager/integration/tests/test_flexvolume.py
+++ b/manager/integration/tests/test_flexvolume.py
@@ -4,7 +4,7 @@ import pytest
 import common
 from common import clients, core_api, volume_name  # NOQA
 from common import Gi, VOLUME_RWTEST_SIZE
-from common import create_and_wait_pod, delete_pod, delete_and_wait_longhorn
+from common import create_and_wait_pod, delete_and_wait_pod, delete_and_wait_longhorn
 from common import generate_random_data, read_volume_data, size_to_string
 from common import write_volume_data
 
@@ -54,7 +54,7 @@ def test_flexvolume_mount(clients, core_api, volume_name): # NOQA
         volume["flexVolume"]["options"]["numberOfReplicas"])
     assert volumes[0]["state"] == "attached"
 
-    delete_pod(core_api, pod_name)
+    delete_and_wait_pod(core_api, pod_name)
     delete_and_wait_longhorn(client, volume['name'])
 
 
@@ -80,7 +80,7 @@ def test_flexvolume_io(clients, core_api, volume_name):  # NOQA
 
     test_data = generate_random_data(VOLUME_RWTEST_SIZE)
     write_volume_data(core_api, pod_name, test_data)
-    delete_pod(core_api, pod_name)
+    delete_and_wait_pod(core_api, pod_name)
     common.wait_for_volume_detached(client, volume["name"])
 
     pod_name = 'volume-driver-io-test-2'
@@ -89,5 +89,5 @@ def test_flexvolume_io(clients, core_api, volume_name):  # NOQA
     resp = read_volume_data(core_api, pod_name)
 
     assert resp == test_data
-    delete_pod(core_api, pod_name)
+    delete_and_wait_pod(core_api, pod_name)
     delete_and_wait_longhorn(client, volume['name'])

--- a/manager/integration/tests/test_provisioner.py
+++ b/manager/integration/tests/test_provisioner.py
@@ -3,7 +3,7 @@ import common
 from common import clients, core_api, pvc_name, volume_name  # NOQA
 from common import DEFAULT_LONGHORN_PARAMS
 from common import DEFAULT_VOLUME_SIZE, Gi, VOLUME_RWTEST_SIZE
-from common import create_and_wait_pod, create_pvc_spec, delete_pod
+from common import create_and_wait_pod, create_pvc_spec, delete_and_wait_pod
 from common import generate_random_data, read_volume_data, size_to_string
 from common import wait_for_volume_delete, write_volume_data
 
@@ -120,7 +120,7 @@ def test_provisioner_mount(clients, core_api, pvc_name):  # NOQA
         int(DEFAULT_LONGHORN_PARAMS["numberOfReplicas"])
     assert volumes[0]["state"] == "attached"
 
-    delete_pod(core_api, pod_name)
+    delete_and_wait_pod(core_api, pod_name)
     delete_and_wait_storage(client, pvc, pvc_volume_name)
 
 
@@ -158,7 +158,7 @@ def test_provisioner_params(clients, core_api, pvc_name):  # NOQA
         int(storage_class["numberOfReplicas"])
     assert volumes[0]["state"] == "attached"
 
-    delete_pod(core_api, pod_name)
+    delete_and_wait_pod(core_api, pod_name)
     delete_and_wait_storage(client, pvc, pvc_volume_name)
 
 
@@ -184,7 +184,7 @@ def test_provisioner_io(clients, core_api, pvc_name):  # NOQA
     create_and_wait_pod(core_api, pod_name, volume)
     pvc_volume_name = get_volume_name(pvc)
     write_volume_data(core_api, pod_name, test_data)
-    delete_pod(core_api, pod_name)
+    delete_and_wait_pod(core_api, pod_name)
 
     common.wait_for_volume_detached(client, pvc_volume_name)
 
@@ -193,5 +193,5 @@ def test_provisioner_io(clients, core_api, pvc_name):  # NOQA
     resp = read_volume_data(core_api, pod_name)
 
     assert resp == test_data
-    delete_pod(core_api, pod_name)
+    delete_and_wait_pod(core_api, pod_name)
     delete_and_wait_storage(client, pvc, pvc_volume_name)


### PR DESCRIPTION
The volume will only be detached after pod is gone. So we don't want to count
the time of pod shutting down into the volume detaching.