### PR TITLE
Add single client fixture

### DIFF
--- a/manager/integration/tests/test_csi.py
+++ b/manager/integration/tests/test_csi.py
@@ -2,21 +2,21 @@
 import pytest
 
 import common
-from common import clients, core_api, csi_pv, pod, pvc  # NOQA
+from common import client, core_api, csi_pv, pod, pvc  # NOQA
 from common import Gi, DEFAULT_VOLUME_SIZE, VOLUME_RWTEST_SIZE
 from common import create_and_wait_pod, create_pvc_spec, delete_and_wait_pod
 from common import generate_random_data, read_volume_data, write_volume_data
 
 
-def create_pv_storage(api, client, pv, claim):
+def create_pv_storage(api, cli, pv, claim):
     """
     Manually create a new PV and PVC for testing.
     """
-    client.create_volume(
+    cli.create_volume(
         name=pv['metadata']['name'], size=pv['spec']['capacity']['storage'],
         numberOfReplicas=int(pv['spec']['csi']['volumeAttributes']
                              ['numberOfReplicas']))
-    common.wait_for_volume_detached(client, pv['metadata']['name'])
+    common.wait_for_volume_detached(cli, pv['metadata']['name'])
 
     api.create_persistent_volume(pv)
     api.create_namespaced_persistent_volume_claim(
@@ -25,7 +25,7 @@ def create_pv_storage(api, client, pv, claim):
 
 
 @pytest.mark.csi  # NOQA
-def test_csi_mount(clients, core_api, csi_pv, pvc, pod): # NOQA
+def test_csi_mount(client, core_api, csi_pv, pvc, pod): # NOQA
     """
     Test that a statically defined CSI volume can be created, mounted,
     unmounted, and deleted properly on the Kubernetes cluster.
@@ -33,8 +33,6 @@ def test_csi_mount(clients, core_api, csi_pv, pvc, pod): # NOQA
     Fixtures are torn down here in reverse order that they are specified as a
     parameter. Take caution when reordering test fixtures.
     """
-    for _, client in clients.iteritems():
-        break
 
     pod_name = 'csi-mount-test'
     pod['metadata']['name'] = pod_name
@@ -57,7 +55,7 @@ def test_csi_mount(clients, core_api, csi_pv, pvc, pod): # NOQA
 
 
 @pytest.mark.csi  # NOQA
-def test_csi_io(clients, core_api, csi_pv, pvc, pod):  # NOQA
+def test_csi_io(client, core_api, csi_pv, pvc, pod):  # NOQA
     """
     Test that input and output on a statically defined CSI volume works as
     expected.
@@ -65,8 +63,6 @@ def test_csi_io(clients, core_api, csi_pv, pvc, pod):  # NOQA
     Fixtures are torn down here in reverse order that they are specified as a
     parameter. Take caution when reordering test fixtures.
     """
-    for _, client in clients.iteritems():
-        break
     pod_name = 'csi-io-test'
     pod['metadata']['name'] = pod_name
     pod['spec']['volumes'] = [

--- a/manager/integration/tests/test_engine_upgrade.py
+++ b/manager/integration/tests/test_engine_upgrade.py
@@ -1,7 +1,7 @@
 import pytest
 
 import common
-from common import clients, volume_name  # NOQA
+from common import client, volume_name  # NOQA
 from common import SIZE
 from common import check_data, get_self_host_id
 from common import wait_for_volume_current_image, wait_for_volume_delete
@@ -11,11 +11,7 @@ from common import write_random_data
 REPLICA_COUNT = 2
 
 
-def test_engine_image(clients, volume_name):  # NOQA
-    # get a random client
-    for _, client in clients.iteritems():
-        break
-
+def test_engine_image(client, volume_name):  # NOQA
     # can be leftover
     default_img = common.get_default_engine_image(client)
     default_img_name = default_img["name"]
@@ -74,11 +70,7 @@ def test_engine_image(clients, volume_name):  # NOQA
     client.delete(new_img)
 
 
-def test_engine_offline_upgrade(clients, volume_name):  # NOQA
-    # get a random client
-    for _, client in clients.iteritems():
-        break
-
+def test_engine_offline_upgrade(client, volume_name):  # NOQA
     default_img = common.get_default_engine_image(client)
     default_img_name = default_img["name"]
     default_img = wait_for_engine_image_ref_count(client, default_img_name, 0)
@@ -175,11 +167,7 @@ def test_engine_offline_upgrade(clients, volume_name):  # NOQA
     client.delete(new_img)
 
 
-def test_engine_live_upgrade(clients, volume_name):  # NOQA
-    # get a random client
-    for _, client in clients.iteritems():
-        break
-
+def test_engine_live_upgrade(client, volume_name):  # NOQA
     default_img = common.get_default_engine_image(client)
     default_img_name = default_img["name"]
     default_img = wait_for_engine_image_ref_count(client, default_img_name, 0)
@@ -299,11 +287,7 @@ def test_engine_live_upgrade(clients, volume_name):  # NOQA
     client.delete(new_img)
 
 
-def test_engine_image_incompatible(clients, volume_name):  # NOQA
-    # get a random client
-    for _, client in clients.iteritems():
-        break
-
+def test_engine_image_incompatible(client, volume_name):  # NOQA
     images = client.list_engine_image()
     assert len(images) == 1
     assert images[0]["default"]
@@ -341,11 +325,7 @@ def test_engine_image_incompatible(clients, volume_name):  # NOQA
     client.delete(img)
 
 
-def test_engine_live_upgrade_rollback(clients, volume_name):  # NOQA
-    # get a random client
-    for _, client in clients.iteritems():
-        break
-
+def test_engine_live_upgrade_rollback(client, volume_name):  # NOQA
     default_img = common.get_default_engine_image(client)
     default_img_name = default_img["name"]
     default_img = wait_for_engine_image_ref_count(client, default_img_name, 0)

--- a/manager/integration/tests/test_flexvolume.py
+++ b/manager/integration/tests/test_flexvolume.py
@@ -2,7 +2,7 @@
 import pytest
 
 import common
-from common import clients, core_api, flexvolume, pod  # NOQA
+from common import client, core_api, flexvolume, pod  # NOQA
 from common import Gi, DEFAULT_VOLUME_SIZE, VOLUME_RWTEST_SIZE
 from common import create_and_wait_pod, delete_and_wait_pod
 from common import generate_random_data, read_volume_data
@@ -10,7 +10,7 @@ from common import wait_for_volume_detached
 
 
 @pytest.mark.flexvolume  # NOQA
-def test_flexvolume_mount(clients, core_api, flexvolume, pod): # NOQA
+def test_flexvolume_mount(client, core_api, flexvolume, pod): # NOQA
     """
     Test that a statically defined volume can be created, mounted, unmounted,
     and deleted properly on the Kubernetes cluster.
@@ -18,8 +18,6 @@ def test_flexvolume_mount(clients, core_api, flexvolume, pod): # NOQA
     Fixtures are torn down here in reverse order that they are specified as a
     parameter. Take caution when reordering test fixtures.
     """
-    for _, client in clients.iteritems():
-        break
 
     pod_name = 'flexvolume-mount-test'
     pod['metadata']['name'] = pod_name
@@ -42,7 +40,7 @@ def test_flexvolume_mount(clients, core_api, flexvolume, pod): # NOQA
 
 
 @pytest.mark.flexvolume  # NOQA
-def test_flexvolume_io(clients, core_api, flexvolume, pod):  # NOQA
+def test_flexvolume_io(client, core_api, flexvolume, pod):  # NOQA
     """
     Test that input and output on a statically defined volume works as
     expected.
@@ -50,8 +48,6 @@ def test_flexvolume_io(clients, core_api, flexvolume, pod):  # NOQA
     Fixtures are torn down here in reverse order that they are specified as a
     parameter. Take caution when reordering test fixtures.
     """
-    for _, client in clients.iteritems():
-        break
 
     pod_name = 'flexvolume-io-test'
     pod['metadata']['name'] = pod_name

--- a/manager/integration/tests/test_ha.py
+++ b/manager/integration/tests/test_ha.py
@@ -1,17 +1,15 @@
 import common
 import time
 
-from common import clients, volume_name  # NOQA
+from common import client, volume_name  # NOQA
 from common import SIZE, DEV_PATH
 from common import check_data, get_self_host_id
 from common import write_random_data
 from common import RETRY_COUNTS, RETRY_ITERVAL
 
 
-def test_ha_simple_recovery(clients, volume_name):  # NOQA
+def test_ha_simple_recovery(client, volume_name):  # NOQA
     # get a random client
-    for _, client in clients.iteritems():
-        break
 
     volume = client.create_volume(name=volume_name, size=SIZE,
                                   numberOfReplicas=2)
@@ -80,10 +78,8 @@ def test_ha_simple_recovery(clients, volume_name):  # NOQA
     assert len(volumes) == 0
 
 
-def test_ha_salvage(clients, volume_name):  # NOQA
+def test_ha_salvage(client, volume_name):  # NOQA
     # get a random client
-    for _, client in clients.iteritems():
-        break
 
     volume = client.create_volume(name=volume_name, size=SIZE,
                                   numberOfReplicas=2)

--- a/manager/integration/tests/test_provisioner.py
+++ b/manager/integration/tests/test_provisioner.py
@@ -1,7 +1,7 @@
 #!/usr/sbin/python
 import common
 
-from common import clients, core_api, pod, pvc, storage_class  # NOQA
+from common import client, core_api, pod, pvc, storage_class  # NOQA
 from common import DEFAULT_VOLUME_SIZE, Gi, VOLUME_RWTEST_SIZE
 from common import create_and_wait_pod, create_pvc_spec, delete_and_wait_pod
 from common import generate_random_data, get_storage_api_client
@@ -24,7 +24,7 @@ def create_storage(api, sc_manifest, pvc_manifest):
         namespace='default')
 
 
-def test_provisioner_mount(clients, core_api, storage_class, pvc, pod):  # NOQA
+def test_provisioner_mount(client, core_api, storage_class, pvc, pod):  # NOQA
     """
     Test that a StorageClass provisioned volume can be created, mounted,
     unmounted, and deleted properly on the Kubernetes cluster.
@@ -32,8 +32,6 @@ def test_provisioner_mount(clients, core_api, storage_class, pvc, pod):  # NOQA
     Fixtures are torn down here in reverse order that they are specified as a
     parameter. Take caution when reordering test fixtures.
     """
-    for _, client in clients.iteritems():
-        break
 
     # Prepare pod and volume specs.
     pod_name = 'provisioner-mount-test'
@@ -59,7 +57,7 @@ def test_provisioner_mount(clients, core_api, storage_class, pvc, pod):  # NOQA
     assert volumes[0]["state"] == "attached"
 
 
-def test_provisioner_params(clients, core_api, storage_class, pvc, pod):  # NOQA
+def test_provisioner_params(client, core_api, storage_class, pvc, pod):  # NOQA
     """
     Test that substituting different StorageClass parameters is reflected in
     the resulting PersistentVolumeClaim.
@@ -67,8 +65,6 @@ def test_provisioner_params(clients, core_api, storage_class, pvc, pod):  # NOQA
     Fixtures are torn down here in reverse order that they are specified as a
     parameter. Take caution when reordering test fixtures.
     """
-    for _, client in clients.iteritems():
-        break
 
     # Prepare pod and volume specs.
     pod_name = 'provisioner-params-test'
@@ -100,7 +96,7 @@ def test_provisioner_params(clients, core_api, storage_class, pvc, pod):  # NOQA
     assert volumes[0]["state"] == "attached"
 
 
-def test_provisioner_io(clients, core_api, storage_class, pvc, pod):  # NOQA
+def test_provisioner_io(client, core_api, storage_class, pvc, pod):  # NOQA
     """
     Test that input and output on a StorageClass provisioned
     PersistentVolumeClaim works as expected.
@@ -108,8 +104,6 @@ def test_provisioner_io(clients, core_api, storage_class, pvc, pod):  # NOQA
     Fixtures are torn down here in reverse order that they are specified as a
     parameter. Take caution when reordering test fixtures.
     """
-    for _, client in clients.iteritems():
-        break
 
     # Prepare pod and volume specs.
     pod_name = 'provisioner-io-test'

--- a/manager/integration/tests/test_statefulset.py
+++ b/manager/integration/tests/test_statefulset.py
@@ -4,7 +4,7 @@ import time
 
 from random import randrange
 
-from common import clients, core_api, statefulset, storage_class  # NOQA
+from common import client, core_api, statefulset, storage_class  # NOQA
 from common import DEFAULT_POD_INTERVAL, DEFAULT_POD_TIMEOUT
 from common import VOLUME_RWTEST_SIZE
 from common import generate_random_data, get_apps_api_client
@@ -66,13 +66,11 @@ def update_test_manifests(statefulset_manifest, sc_manifest, name):
     sc_manifest['metadata']['name'] = DEFAULT_STORAGECLASS_NAME
 
 
-def test_statefulset_mount(clients, core_api, storage_class, statefulset):  # NOQA
+def test_statefulset_mount(client, core_api, storage_class, statefulset):  # NOQA
     """
     Tests that volumes provisioned for a StatefulSet can be properly created,
     mounted, unmounted, and deleted on the Kubernetes cluster.
     """
-    for _, client in clients.iteritems():
-        break
 
     statefulset_name = 'statefulset-mount-test'
     update_test_manifests(statefulset, storage_class, statefulset_name)
@@ -102,12 +100,10 @@ def test_statefulset_mount(clients, core_api, storage_class, statefulset):  # NO
     assert len(pod_info) == 0
 
 
-def test_statefulset_scaling(clients, core_api, storage_class, statefulset):  # NOQA
+def test_statefulset_scaling(client, core_api, storage_class, statefulset):  # NOQA
     """
     Test that scaling up a StatefulSet successfully provisions new volumes.
     """
-    for _, client in clients.iteritems():
-        break
 
     statefulset_name = 'statefulset-scaling-test'
     update_test_manifests(statefulset, storage_class, statefulset_name)
@@ -204,12 +200,10 @@ def test_statefulset_pod_deletion(core_api, storage_class, statefulset):  # NOQA
     assert resp == test_data
 
 
-def test_statefulset_backup(clients, core_api, storage_class, statefulset):  # NOQA
+def test_statefulset_backup(client, core_api, storage_class, statefulset):  # NOQA
     """
     Test that backups on StatefulSet volumes work properly.
     """
-    for _, client in clients.iteritems():
-        break
 
     statefulset_name = 'statefulset-backup-test'
     update_test_manifests(statefulset, storage_class, statefulset_name)
@@ -269,13 +263,11 @@ def test_statefulset_backup(clients, core_api, storage_class, statefulset):  # N
 
 
 @pytest.mark.recurring_job  # NOQA
-def test_statefulset_recurring_backup(clients, core_api, storage_class,  # NOQA
+def test_statefulset_recurring_backup(client, core_api, storage_class,  # NOQA
                                       statefulset):  # NOQA
     """
     Test that recurring backups on StatefulSets work properly.
     """
-    for _, client in clients.iteritems():
-        break
 
     statefulset_name = 'statefulset-backup-test'
     update_test_manifests(statefulset, storage_class, statefulset_name)


### PR DESCRIPTION
This PR introduces a new fixture called `client` that returns a single client instance rather than multiple of them. This solves the issue of many of the tests using `clients` but only requiring one `client` and needing to use the same `for` block to remedy for it.

Tests that use one `client` now use this fixture and have had the associated `for` statements removed. `clients` has been renamed to `clis` to prevent confusion, and the tests still using this fixture have been modified accordingly. Some tests require a host_id despite using one client, and since `client` doesn't return a host_id, those tests will still be using `clis`.

This PR resolves #75.