### PR TITLE
Add StatefulSet restore test

### DIFF
--- a/manager/integration/tests/test_statefulset.py
+++ b/manager/integration/tests/test_statefulset.py
@@ -5,13 +5,15 @@ import time
 from random import randrange
 
 from common import client, core_api, statefulset, storage_class  # NOQA
-from common import DEFAULT_POD_INTERVAL, DEFAULT_POD_TIMEOUT
-from common import VOLUME_RWTEST_SIZE
-from common import generate_random_data, get_apps_api_client
-from common import get_statefulset_pod_info, get_storage_api_client
-from common import read_volume_data, write_volume_data
+from common import DEFAULT_BACKUP_TIMEOUT, DEFAULT_POD_INTERVAL
+from common import DEFAULT_POD_TIMEOUT, VOLUME_RWTEST_SIZE
+from common import delete_and_wait_statefulset, generate_random_data
+from common import get_apps_api_client, get_statefulset_pod_info
+from common import get_storage_api_client, read_volume_data, size_to_string
+from common import wait_for_volume_detached, write_volume_data
 
 from kubernetes import client as k8sclient
+from kubernetes.client.rest import ApiException
 
 Gi = (1 * 1024 * 1024 * 1024)
 
@@ -31,6 +33,70 @@ def create_and_wait_statefulset(statefulset_manifest):
         body=statefulset_manifest,
         namespace='default')
     wait_statefulset(statefulset_manifest)
+
+
+def create_and_test_backups(api, cli, pod_info):
+    """
+    Create backups for all Pods in a StatefulSet and tests that all the backups
+    have the correct attributes.
+
+    Args:
+        api: An instance of CoreV1Api.
+        cli: A Longhorn client instance.
+        pod_info: A List of Pods with names and volume information. This List
+            can be generated using the get_statefulset_pod_info function
+            located in common.py.
+    """
+    for pod in pod_info:
+        pod['data'] = generate_random_data(VOLUME_RWTEST_SIZE)
+        pod['backup_snapshot'] = ''
+
+        # Create backup.
+        volume = cli.by_id_volume(pod['pv_name'])
+        volume.snapshotCreate()
+        write_volume_data(api, pod['pod_name'], pod['data'])
+        pod['backup_snapshot'] = volume.snapshotCreate()
+        volume.snapshotCreate()
+        volume.snapshotBackup(name=pod['backup_snapshot']['name'])
+
+        # Wait for backup to appear.
+        found = False
+        for i in range(DEFAULT_BACKUP_TIMEOUT):
+            backup_volumes = cli.list_backupVolume()
+            for bv in backup_volumes:
+                if bv['name'] == pod['pv_name']:
+                    found = True
+                    break
+            if found:
+                break
+            time.sleep(DEFAULT_POD_INTERVAL)
+        assert found
+
+        found = False
+        for i in range(DEFAULT_BACKUP_TIMEOUT):
+            backups = bv.backupList()
+            for b in backups:
+                if b['snapshotName'] == pod['backup_snapshot']['name']:
+                    found = True
+                    break
+            if found:
+                break
+            time.sleep(DEFAULT_POD_INTERVAL)
+        assert found
+
+        # Make sure backup has the correct attributes.
+        new_b = bv.backupGet(name=b["name"])
+        assert new_b["name"] == b["name"]
+        assert new_b["url"] == b["url"]
+        assert new_b["snapshotName"] == b["snapshotName"]
+        assert new_b["snapshotCreated"] == b["snapshotCreated"]
+        assert new_b["created"] == b["created"]
+        assert new_b["volumeName"] == b["volumeName"]
+        assert new_b["volumeSize"] == b["volumeSize"]
+        assert new_b["volumeCreated"] == b["volumeCreated"]
+
+        # This backup has the url attribute we need to restore from backup.
+        pod['backup_snapshot'] = b
 
 
 def wait_statefulset(statefulset_manifest):
@@ -211,55 +277,8 @@ def test_statefulset_backup(client, core_api, storage_class, statefulset):  # NO
     create_storage_class(storage_class)
     create_and_wait_statefulset(statefulset)
 
-    pod_data = get_statefulset_pod_info(core_api, statefulset)
-    for pod in pod_data:
-        pod['data'] = generate_random_data(VOLUME_RWTEST_SIZE)
-        pod['backup_snapshot'] = ''
-
-    for pod in pod_data:
-        # Create backup.
-        volume = client.by_id_volume(pod['pv_name'])
-        volume.snapshotCreate()
-        write_volume_data(core_api, pod['pod_name'], pod['data'])
-        pod['backup_snapshot'] = volume.snapshotCreate()
-        volume.snapshotCreate()
-        volume.snapshotBackup(name=pod['backup_snapshot']['name'])
-
-        # Wait for backup to appear.
-        found = False
-        for i in range(100):
-            backup_volumes = client.list_backupVolume()
-            for bv in backup_volumes:
-                if bv['name'] == pod['pv_name']:
-                    found = True
-                    break
-            if found:
-                break
-            time.sleep(DEFAULT_POD_INTERVAL)
-        assert found
-
-        found = False
-        for i in range(20):
-            backups = bv.backupList()
-            for b in backups:
-                if b['snapshotName'] == pod['backup_snapshot']['name']:
-                    found = True
-                    break
-            if found:
-                break
-            time.sleep(DEFAULT_POD_INTERVAL)
-        assert found
-
-        # Make sure backup has the correct attributes.
-        new_b = bv.backupGet(name=b["name"])
-        assert new_b["name"] == b["name"]
-        assert new_b["url"] == b["url"]
-        assert new_b["snapshotName"] == b["snapshotName"]
-        assert new_b["snapshotCreated"] == b["snapshotCreated"]
-        assert new_b["created"] == b["created"]
-        assert new_b["volumeName"] == b["volumeName"]
-        assert new_b["volumeSize"] == b["volumeSize"]
-        assert new_b["volumeCreated"] == b["volumeCreated"]
+    pod_info = get_statefulset_pod_info(core_api, statefulset)
+    create_and_test_backups(core_api, client, pod_info)
 
 
 @pytest.mark.recurring_job  # NOQA
@@ -299,3 +318,131 @@ def test_statefulset_recurring_backup(client, core_api, storage_class,  # NOQA
                 count += 1
 
         assert count == 2
+
+
+def test_statefulset_restore(client, core_api, storage_class,  # NOQA
+                             statefulset):  # NOQA
+    """
+    Test that data can be restored into volumes usable by a StatefulSet.
+    """
+    statefulset_name = 'statefulset-restore-test'
+    update_test_manifests(statefulset, storage_class, statefulset_name)
+
+    create_storage_class(storage_class)
+    create_and_wait_statefulset(statefulset)
+
+    pod_info = get_statefulset_pod_info(core_api, statefulset)
+    create_and_test_backups(core_api, client, pod_info)
+
+    delete_and_wait_statefulset(core_api, client, statefulset)
+
+    csi = True
+    try:
+        core_api.read_namespaced_pod(
+            name='csi-provisioner-0', namespace='longhorn-system')
+    except ApiException as e:
+        if (e.status == 404):
+            csi = False
+
+    # StatefulSet fixture already cleans these up, use the manifests instead of
+    # the fixtures to avoid issues during teardown.
+    pv = {
+        'apiVersion': 'v1',
+        'kind': 'PersistentVolume',
+        'metadata': {
+            'name': ''
+        },
+        'spec': {
+            'capacity': {
+                'storage': size_to_string(DEFAULT_VOLUME_SIZE * Gi)
+            },
+            'volumeMode': 'Filesystem',
+            'accessModes': ['ReadWriteOnce'],
+            'persistentVolumeReclaimPolicy': 'Delete',
+            'storageClassName': DEFAULT_STORAGECLASS_NAME
+        }
+    }
+
+    pvc = {
+        'apiVersion': 'v1',
+        'kind': 'PersistentVolumeClaim',
+        'metadata': {
+            'name': ''
+        },
+        'spec': {
+            'accessModes': [
+                'ReadWriteOnce'
+            ],
+            'resources': {
+                'requests': {
+                    'storage': size_to_string(DEFAULT_VOLUME_SIZE * Gi)
+                }
+            },
+            'storageClassName': DEFAULT_STORAGECLASS_NAME
+        }
+    }
+
+    if csi:
+        pv['spec']['csi'] = {
+            'driver': 'io.rancher.longhorn',
+            'fsType': 'ext4',
+            'volumeAttributes': {
+                'numberOfReplicas':
+                    storage_class['parameters']['numberOfReplicas'],
+                'staleReplicaTimeout':
+                    storage_class['parameters']['staleReplicaTimeout']
+            },
+            'volumeHandle': ''
+        }
+    else:
+        pv['spec']['flexVolume'] = {
+            'driver': 'rancher.io/longhorn',
+            'fsType': 'ext4',
+            'options': {
+                'numberOfReplicas':
+                    storage_class['parameters']['numberOfReplicas'],
+                'staleReplicaTimeout':
+                    storage_class['parameters']['staleReplicaTimeout'],
+                'fromBackup': '',
+                'size': size_to_string(DEFAULT_VOLUME_SIZE * Gi)
+            }
+        }
+
+    # Make sure that volumes still work even if the Pod and StatefulSet names
+    # are different.
+    for pod in pod_info:
+        pod['pod_name'] = pod['pod_name'].replace('statefulset-restore-test',
+                                                  'statefulset-restore-test-2')
+        pod['pvc_name'] = pod['pvc_name'].replace('statefulset-restore-test',
+                                                  'statefulset-restore-test-2')
+
+        pv['metadata']['name'] = pod['pvc_name']
+        if csi:
+            client.create_volume(
+                name=pod['pvc_name'],
+                size=size_to_string(DEFAULT_VOLUME_SIZE * Gi),
+                numberOfReplicas=int(
+                    storage_class['parameters']['numberOfReplicas']),
+                fromBackup=pod['backup_snapshot']['url'])
+            wait_for_volume_detached(client, pod['pvc_name'])
+
+            pv['spec']['csi']['volumeHandle'] = pod['pvc_name']
+        else:
+            pv['spec']['flexVolume']['options']['fromBackup'] = \
+                pod['backup_snapshot']['url']
+
+        core_api.create_persistent_volume(pv)
+
+        pvc['metadata']['name'] = pod['pvc_name']
+        pvc['spec']['volumeName'] = pod['pvc_name']
+        core_api.create_namespaced_persistent_volume_claim(
+            body=pvc,
+            namespace='default')
+
+    statefulset_name = 'statefulset-restore-test-2'
+    update_test_manifests(statefulset, storage_class, statefulset_name)
+    create_and_wait_statefulset(statefulset)
+
+    for pod in pod_info:
+        resp = read_volume_data(core_api, pod['pod_name'])
+        assert resp == pod['data']


### PR DESCRIPTION
This PR implements the last test requested in #55, which backs up a StatefulSet, creates a new set of volumes to be used for the StatefulSet, and then confirms that the volumes hold their existing data in a new StatefulSet.

To support this new test, part of the common functions have been rewritten:
- `delete_and_wait_pod` now calls a separate `wait_pod` function that is also used by the `statefulset` fixture teardown procedure.
- The `statefulset` fixture teardown now waits on the `PersistentVolume` to see if it will enter a `Failed` state (expected of manually created volumes) and tear those volumes down manually rather than timing out and causing an error.
- The `statefulset` fixture teardown now calls `delete_and_wait_statefulset`, a function that is also used by the `test_statefulset_restore` test.
- The `test_statefulset_backup` and `test_statefulset_restore` tests now both call a `create_and_test_backups` function to avoid duplicate code.

Separate tests have been written for FlexVolume and CSI due to differences in how Longhorn volumes are created between the two types of storage plugins.

This PR resolves #55.