### PR TITLE
manager: disable node test by default

### DIFF
--- a/manager/integration/tests/conftest.py
+++ b/manager/integration/tests/conftest.py
@@ -7,6 +7,7 @@ from kubernetes.client.rest import ApiException
 ENABLE_RECURRING_JOB_OPT = "--enable-recurring-job-test"
 ENABLE_FLEXVOLUME_OPT = "--enable-flexvolume-test"
 ENABLE_CSI_OPT = "--enable-csi-test"
+ENABLE_NODE_OPT = "--enable-node-test"
 
 
 def pytest_addoption(parser):
@@ -16,6 +17,9 @@ def pytest_addoption(parser):
     parser.addoption(ENABLE_FLEXVOLUME_OPT, action="store_true",
                      default=False,
                      help="enable Flexvolume test or not")
+    parser.addoption(ENABLE_NODE_OPT, action="store_true",
+                     default=False,
+                     help="enable node test or not")
 
 
 def pytest_collection_modifyitems(config, items):
@@ -26,6 +30,13 @@ def pytest_collection_modifyitems(config, items):
         for item in items:
             if "recurring_job" in item.keywords:
                 item.add_marker(skip_upgrade)
+    if not config.getoption(ENABLE_NODE_OPT):
+        skip_node = pytest.mark.skip(reason="need " +
+                                     ENABLE_NODE_OPT +
+                                     " option to run")
+        for item in items:
+            if "node" in item.keywords:
+                item.add_marker(skip_node)
 
     c = Configuration()
     c.assert_hostname = False

--- a/manager/integration/tests/test_node.py
+++ b/manager/integration/tests/test_node.py
@@ -37,6 +37,7 @@ def get_update_disks(disks):
     return update_disk
 
 
+@pytest.mark.node  # NOQA
 def test_node(client):  # NOQA
     # test node update
     nodes = client.list_node()
@@ -182,6 +183,7 @@ def cleanup_volume(client, vol_name):  # NOQA
     common.wait_for_volume_delete(client, vol_name)
 
 
+@pytest.mark.node  # NOQA
 def test_replica_scheduler(client):  # NOQA
     nodes = client.list_node()
     # delete all disks on each node
@@ -336,6 +338,7 @@ def test_replica_scheduler(client):  # NOQA
     cleanup_host_disk(client, 'vol-small')
 
 
+@pytest.mark.node  # NOQA
 def test_node_controller(client):  # NOQA
     lht_hostId = get_self_host_id()
     nodes = client.list_node()


### PR DESCRIPTION
It has high failure rate right now due to API server issues.

Use `--enable-node-test` option to enable the test.