### PR TITLE
Clear output of mkfs.ext4, mount and umount operation

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -1066,26 +1066,28 @@ def get_upgrade_test_image(cli_v, cli_minv,
 
 
 def prepare_host_disk(dev, vol_name):
+    FNULL = open('py.stdout', 'w', 0)
     cmd = ['mkfs.ext4', dev]
-    subprocess.check_call(cmd)
+    subprocess.check_call(cmd, stdout=FNULL, stderr=subprocess.STDOUT)
 
     mount_path = os.path.join(DIRECTORY_PATH, vol_name)
     # create directory before mount
     cmd = ['mkdir', '-p', mount_path]
-    subprocess.check_call(cmd)
+    subprocess.check_call(cmd, stdout=FNULL, stderr=subprocess.STDOUT)
 
     cmd = ['mount', dev, mount_path]
-    subprocess.check_call(cmd)
+    subprocess.check_call(cmd, stdout=FNULL, stderr=subprocess.STDOUT)
     return mount_path
 
 
 def cleanup_host_disk(vol_name):
+    FNULL = open('py.stdout', 'w', 0)
     mount_path = os.path.join(DIRECTORY_PATH, vol_name)
     cmd = ['umount', mount_path]
-    subprocess.check_call(cmd)
+    subprocess.check_call(cmd, stdout=FNULL, stderr=subprocess.STDOUT)
 
     cmd = ['rm', '-r', mount_path]
-    subprocess.check_call(cmd)
+    subprocess.check_call(cmd, stdout=FNULL, stderr=subprocess.STDOUT)
 
 
 def wait_for_volume_condition_scheduled(client, name, key, value):

--- a/manager/integration/tests/test_node.py
+++ b/manager/integration/tests/test_node.py
@@ -594,8 +594,9 @@ def test_node_controller(client):  # NOQA
     test_file_path = os.path.join(test_disk_path, TEST_FILE)
     if os.path.exists(test_file_path):
         os.remove(test_file_path)
+    FNULL = open('py.stdout', 'w', 0)
     cmd = ['dd', 'if=/dev/zero', 'of=' + test_file_path, 'bs=1M', 'count=1']
-    subprocess.check_call(cmd)
+    subprocess.check_call(cmd, stdout=FNULL, stderr=subprocess.STDOUT)
     node = client.by_id_node(lht_hostId)
     disks = node["disks"]
     # wait for node controller update disk status


### PR DESCRIPTION
Fixed issue: https://github.com/rancher/longhorn/issues/139