### PR TITLE
Verify volume checksums in tests

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -927,29 +927,6 @@ def generate_random_data(count):
                    for _ in range(count))
 
 
-def check_data(v, data):
-    """
-    Checks if the data written on the block device matches the inputted data.
-    """
-    resp = volume_read(v, data['pos'], data['len'])
-    assert resp == data['content']
-
-
-def write_random_data(v):
-    """
-    Generate random data and write it to the specified block device.
-    """
-    data = generate_random_data(VOLUME_RWTEST_SIZE)
-    data_pos = generate_random_pos(VOLUME_RWTEST_SIZE)
-    data_len = volume_write(v, data_pos, data)
-
-    return {
-        'content': data,
-        'pos': data_pos,
-        'len': data_len
-    }
-
-
 def check_volume_data(volume, data):
     dev = get_volume_endpoint(volume)
     check_device_data(dev, data)

--- a/manager/integration/tests/test_ha.py
+++ b/manager/integration/tests/test_ha.py
@@ -4,10 +4,9 @@ import time
 
 from common import client, volume_name  # NOQA
 from common import SIZE, DEV_PATH
-from common import check_data, get_self_host_id
-from common import write_random_data
+from common import check_volume_data, get_self_host_id, get_volume_endpoint
+from common import write_volume_random_data
 from common import RETRY_COUNTS, RETRY_ITERVAL
-from common import get_volume_endpoint
 
 
 @pytest.mark.coretest   # NOQA
@@ -40,7 +39,7 @@ def ha_simple_recovery_test(client, volume_name, size, base_image=""):  # NOQA
     replica1 = volume["replicas"][1]
     assert replica1["name"] != ""
 
-    data = write_random_data(volume)
+    data = write_volume_random_data(volume)
 
     volume = volume.replicaRemove(name=replica0["name"])
 
@@ -72,7 +71,7 @@ def ha_simple_recovery_test(client, volume_name, size, base_image=""):  # NOQA
             break
     assert found
 
-    check_data(volume, data)
+    check_volume_data(volume, data)
 
     volume = volume.detach()
     volume = common.wait_for_volume_detached(client, volume_name)
@@ -108,7 +107,7 @@ def ha_salvage_test(client, volume_name, base_image=""):  # NOQA
     replica0_name = volume["replicas"][0]["name"]
     replica1_name = volume["replicas"][1]["name"]
 
-    data = write_random_data(volume)
+    data = write_volume_random_data(volume)
 
     common.k8s_delete_replica_pods_for_volume(volume_name)
 
@@ -127,7 +126,7 @@ def ha_salvage_test(client, volume_name, base_image=""):  # NOQA
     volume = volume.attach(hostId=host_id)
     volume = common.wait_for_volume_healthy(client, volume_name)
 
-    check_data(volume, data)
+    check_volume_data(volume, data)
 
     volume = volume.detach()
     volume = common.wait_for_volume_detached(client, volume_name)


### PR DESCRIPTION
This PR adds four new functions in order to verify volume checksums in tests:
- `write_device_rdata`
- `check_device_data`
- `write_volume_rdata`
- `check_volume_data`

These functions will check both write data at a specific position (which we were already checking) and verify the checksum of the volume. This allows us to confirm that data is properly written to the volume (write data) and that the volume properly maintains its state in its entirety (checksum).

The tests that rely on this data verification right now (`test_basic.py`, `test_engine_upgrade.py`, and `test_ha.py`) have been modified to use these new functions.

The old `write_random_data` and `check_data` methods have been removed in favor of these new methods.

This PR resolves rancher/longhorn#147.