### PR TITLE
Update image to rancher/longhorn-manager-test:1b8c791

### DIFF
--- a/manager/integration/deploy/test.yaml
+++ b/manager/integration/deploy/test.yaml
@@ -40,7 +40,7 @@ metadata:
 spec:
   containers:
   - name: longhorn-test-pod
-    image: rancher/longhorn-manager-test:986d13b
+    image: rancher/longhorn-manager-test:1b8c791
 #    args: ["-x", "-s",
 #           "-m", "coretest",
 #           "-k", "test_recurring_job",


### PR DESCRIPTION
Matches manager:

commit 04de3c050450e969486119943349eb1a01fc1f52
Author: Sheng Yang <sheng@yasker.org>
Date:   Fri Aug 3 17:11:20 2018 -0700

    Update images

    Manager to rancher/longhorn-manager:bdc22c1
    Engine to rancher/longhorn-engine:74ac39a

    Backup/restore with base image support added