### PR TITLE
Add StorageClass references to CSI tests

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -504,9 +504,11 @@ def pvc(request):
             name=pvc_manifest['metadata']['name'], namespace='default',
             body=k8sclient.V1DeleteOptions())
 
+        # Working around line break issue.
+        key = 'volume.beta.kubernetes.io/storage-provisioner'
         # If not using StorageClass (such as in CSI test), the Longhorn volume
         # will not be automatically deleted, causing this to throw an error.
-        if 'storageClassName' in pvc_manifest['spec']:
+        if (key in claim.metadata.annotations):
             client = get_longhorn_api_client()
             wait_for_volume_delete(client, volume_name)
 


### PR DESCRIPTION
This PR adds a `StorageClass` reference to the `PersistentVolumes` and `PersistentVolumeClaims` in `test_csi.py`. This helps work around issues on some platforms such as GKE where a `StorageClass` name is expected or it attempts to use the default, causing the test to fail.

As a result of this, checking for provisioned volumes using the `storageClassName` field no longer works in `PersistentVolumeClaims`. The `pvc` finalizer has been modified to instead check for the `volume.beta.kubernetes.io/storage-provisioner` annotation to check for provisioned volumes.

This PR resolves rancher/longhorn#165.