### PR TITLE
add clean disk after test umount case

### DIFF
--- a/manager/integration/tests/test_node.py
+++ b/manager/integration/tests/test_node.py
@@ -920,3 +920,5 @@ def test_node_delete_umount_disks(client):  # NOQA
     node = common.wait_for_disk_update(client, lht_hostId,
                                        len(update_disks))
     assert len(node["disks"]) == len(update_disks)
+    cmd = ['rm', '-r', mount_path]
+    subprocess.check_call(cmd)


### PR DESCRIPTION
Fixed finalizer error log after running umount disk test case
```
---------------------------- Captured stdout setup -----------------------------
Exception when cleanup host disk vol-disk-1 Command '['umount', '/tmp/longhorn-test/vol-disk-1']' returned non-zero exit status 32
```