### PR TITLE
update tests with backend

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -1348,7 +1348,8 @@ def reset_disks_for_all_nodes(client):  # NOQA
         for fsid, disk in disks.iteritems():
             update_disk = disk
             update_disk["allowScheduling"] = True
-            update_disk["storageReserved"] = 0
+            update_disk["storageReserved"] = \
+                update_disk["storageMaximum"] * 30 / 100
             update_disks.append(update_disk)
         node = node.diskUpdate(disks=update_disks)
         for fsid, disk in node["disks"].iteritems():
@@ -1358,7 +1359,8 @@ def reset_disks_for_all_nodes(client):  # NOQA
             wait_for_disk_status(client, node["name"], fsid,
                                  "storageScheduled", 0)
             wait_for_disk_status(client, node["name"], fsid,
-                                 "storageReserved", 0)
+                                 "storageReserved",
+                                 update_disk["storageMaximum"] * 30 / 100)
 
 
 def reset_settings(client):

--- a/manager/integration/tests/test_node.py
+++ b/manager/integration/tests/test_node.py
@@ -939,6 +939,8 @@ def test_node_delete_umount_disks(client):  # NOQA
             wait_for_disk_status(client, lht_hostId,
                                  fsid, "allowScheduling", False)
             wait_for_disk_status(client, lht_hostId,
+                                 fsid, "storageScheduled", 0)
+            wait_for_disk_status(client, lht_hostId,
                                  fsid, "storageMaximum", 0)
 
     # test delete the umount disk


### PR DESCRIPTION
- After delete replica, still need some time to wait for storageScheduled value update.
- By default, longhorn reserved 30% space for root disks, test finalizer also need to reset reserved value for each root disk.